### PR TITLE
Add `ruff` config

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,6 +4,7 @@
 # sphinx-quickstart on Wed Nov  9 16:42:53 2016.
 import os
 import sys
+
 sys.path.insert(0, os.path.abspath("../lewis"))
 
 
@@ -22,11 +23,11 @@ extensions = [
 ]
 templates_path = ["_templates"]
 # General information about the project.
-project = u"lewis"
-language = 'en'
+project = "lewis"
+language = "en"
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # -- Options for HTML output ---------------------------------------------
-suppress_warnings =["docutils"]
+suppress_warnings = ["docutils"]
 html_theme = "sphinx_rtd_theme"
 html_logo = "resources/logo/lewis-logo.png"
 html_context = {

--- a/lewis/adapters/epics.py
+++ b/lewis/adapters/epics.py
@@ -441,14 +441,14 @@ class PropertyExposingDriver(Driver):
                 return True
         except LimitViolationException as e:
             self.log.warning(
-                "Rejected writing value %s to PV %s due to limit " "violation. %s",
+                "Rejected writing value %s to PV %s due to limit violation. %s",
                 value,
                 pv,
                 e,
             )
         except AccessViolationException:
             self.log.warning(
-                "Rejected writing value %s to PV %s due to access " "violation, PV is read-only.",
+                "Rejected writing value %s to PV %s due to access violation, PV is read-only.",
                 value,
                 pv,
             )

--- a/lewis/adapters/stream.py
+++ b/lewis/adapters/stream.py
@@ -842,7 +842,7 @@ class StreamInterface(InterfaceBase):
                 pattern = bound_cmd.matcher.pattern
                 if pattern in patterns:
                     raise RuntimeError(
-                        "The regular expression {} is " "associated with multiple commands.".format(
+                        "The regular expression {} is associated with multiple commands.".format(
                             pattern
                         )
                     )

--- a/lewis/core/adapters.py
+++ b/lewis/core/adapters.py
@@ -45,8 +45,7 @@ class NoLock:
 
     def __enter__(self) -> None:
         raise RuntimeError(
-            "The attempted action requires a proper threading.Lock-object, "
-            "but none was available."
+            "The attempted action requires a proper threading.Lock-object, but none was available."
         )
 
     def __exit__(

--- a/lewis/core/devices.py
+++ b/lewis/core/devices.py
@@ -349,8 +349,7 @@ class DeviceBuilder:
 
         if setup_name not in self.setups:
             raise LewisException(
-                "Failed to find setup '{}' for device '{}'. "
-                "Available setups are:\n    {}".format(
+                "Failed to find setup '{}' for device '{}'. Available setups are:\n    {}".format(
                     setup, self.name, "\n    ".join(self.setups.keys())
                 )
             )

--- a/lewis/core/statemachine.py
+++ b/lewis/core/statemachine.py
@@ -191,7 +191,7 @@ class StateMachine(CanProcess):
         # Specifying an initial state is not optional
         if "initial" not in cfg:
             raise StateMachineException(
-                "StateMachine configuration must include " "'initial' to specify starting state."
+                "StateMachine configuration must include 'initial' to specify starting state."
             )
         self._initial = cfg["initial"]
         self._set_handlers(self._initial)

--- a/lewis/scripts/control.py
+++ b/lewis/scripts/control.py
@@ -117,7 +117,7 @@ positional_args.add_argument(
 positional_args.add_argument(
     "arguments",
     nargs="*",
-    help="Arguments to method call. For setting a property, " "supply the property value. ",
+    help="Arguments to method call. For setting a property, supply the property value. ",
 )
 
 optional_args = parser.add_argument_group("Optional arguments")

--- a/lewis/scripts/run.py
+++ b/lewis/scripts/run.py
@@ -160,8 +160,7 @@ version_handling.add_argument(
     "-I",
     "--ignore-versions",
     action="store_true",
-    help="Ignore version mismatches between device and framework. A warning will still "
-    "be logged.",
+    help="Ignore version mismatches between device and framework. A warning will still be logged.",
 )
 other_args.add_argument(
     "-v", "--version", action="store_true", help="Prints the version and exits."

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,33 @@
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Set the maximum line length to 100.
+line-length = 100
+indent-width = 4

--- a/tests/test_StateMachine.py
+++ b/tests/test_StateMachine.py
@@ -45,7 +45,7 @@ class TestStateMachine(unittest.TestCase):
         self.assertEqual(
             sm.state,
             "foobar",
-            "StateMachine failed to transition into " "initial state on first cycle",
+            "StateMachine failed to transition into initial state on first cycle",
         )
 
     def test_can_transition_with_lambda(self):


### PR DESCRIPTION
Make our `ruff` config local rather than depending on our `reusable-workflows` copy; this is to make it easier for external contributors outside ISIS to get the relevant `ruff` config.